### PR TITLE
入力確認画面から入力画面への遷移処理作成

### DIFF
--- a/app/Http/Controllers/ConfirmForm/ConfirmFormController.php
+++ b/app/Http/Controllers/ConfirmForm/ConfirmFormController.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace App\Http\Controllers\ConfirmForm;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Validator;
+
+class ConfirmFormController extends Controller
+{
+
+    public $form_data = [
+        ["name", "text"],
+        ["age", "text"],
+        ["email", "emai"],
+    ];
+
+    public function index()
+    {
+        return view('/confirm_form/index',[
+            'form_data' => $this->form_data,
+        ]);
+    }
+
+    public function confirm(Request $request)
+    {
+
+        $validation_array = [
+            'name' => 'required | string',
+            'age' => 'required | numeric',
+            'email' => 'required | email',
+        ];
+
+        $validator = Validator::make($request->all(), $validation_array);
+
+        if ($validator->fails()) {
+            return redirect('/confirm_form/')
+                        ->withErrors($validator)
+                        ->withInput();
+        };
+
+        $input_data = [
+            ["name", $request->input('name')],
+            ["age", $request->input('age')],
+            ["email", $request->input('email')],
+        ];
+
+        return view('confirm_form/confirm',[
+            'input_data' => $input_data,
+        ]);
+    }
+
+    public function complete(Request $request)
+    {
+        if($request->input('back') == 'back'){
+            return redirect('/confirm_form/')
+                        ->withInput();
+        }
+
+        return view('confirm_form/complete');
+    }
+}

--- a/resources/views/confirm_form/complete.blade.php
+++ b/resources/views/confirm_form/complete.blade.php
@@ -1,0 +1,25 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="container">
+    <div class="row justify-content-center">
+        <div class="col-md-8">
+            <div class="card">
+                <div class="card-header">
+                    入力画面から遷移したときの値保持
+                </div>
+                <div class="card-body">
+                    <h2>入力完了画面</h2>
+                    <div class="edit_table">
+                        <p>入力が完了しました</p>
+                    </div>
+                    <div>
+                        <a href="/confirm_form/">入力画面に戻る</a>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+    
+@endsection

--- a/resources/views/confirm_form/confirm.blade.php
+++ b/resources/views/confirm_form/confirm.blade.php
@@ -1,0 +1,42 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="container">
+    <div class="row justify-content-center">
+        <div class="col-md-8">
+            <div class="card">
+                <div class="card-header">
+                    入力画面から遷移したときの値保持
+                </div>
+                <div class="card-body">
+                    <h2>入力確認画面</h2>
+                    <div class="edit_table">
+                        <form method="POST" action="/confirm_form/complete">
+                            <table>
+                                <tr>
+                                    <th>名前</th>
+                                    <th>年齢</th>
+                                    <th>メールアドレス</th>
+                                </tr>
+                                <tr>
+                                    @foreach($input_data as $value)
+                                        <td>{{ $value[1] }}</td>
+                                        <input name="{{ $value[0] }}" type="hidden" value="{{ $value[1] }}">
+                                    @endforeach
+                                 </tr>
+                                 <tr>
+                                    <td><button type="submit" name='back' value="back">修正する</button></td>
+                                    <td><button type="submit" name='submit' value="complete">入力完了画面へ</button></td>
+                                </tr>
+                            </table>
+                            @csrf
+                        </form>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+    
+@endsection
+

--- a/resources/views/confirm_form/index.blade.php
+++ b/resources/views/confirm_form/index.blade.php
@@ -1,0 +1,42 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="container">
+    <div class="row justify-content-center">
+        <div class="col-md-8">
+            <div class="card">
+                <div class="card-header">
+                    入力画面から遷移したときの値保持
+                </div>
+                <div class="card-body">
+                    <h2>入力画面</h2>
+                    <div class="edit_table">
+                        <form method="POST" action="/confirm_form/confirm">
+                            <table>
+                                <tr>
+                                    <th>名前</th>
+                                    <th>年齢</th>
+                                    <th>メールアドレス</th>
+                                </tr>
+                                <tr>
+                                    @foreach($form_data as $value)
+                                        <td>
+                                            <input name="{{ $value[0] }}" type="{{ $value[1] }}" value="{{ old($value[0]) }}">
+                                            @if($errors->has($value[0]))
+                                                <p style="color: red;">{{ $errors->first($value[0]) }}</p>
+                                            @endif 
+                                        </td>
+                                    @endforeach
+                                 	<td><button type="submit">確認画面へ</button></td>
+                                 </tr>
+                            </table>
+                            @csrf
+                        </form>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+	
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -81,3 +81,7 @@ Route::get('/admin/works/delete_check','AdminController@admin');
 Route::post('/admin/works/delete_check','Works\DeleteCheckController@delete_check');
 Route::get('/admin/works/delete_finish','AdminController@admin');
 Route::post('/admin/works/delete_finish','Works\DeleteFinishController@delete_finish');
+
+Route::get('/confirm_form/','ConfirmForm\ConfirmFormController@index');
+Route::post('/confirm_form/confirm/','ConfirmForm\ConfirmFormController@confirm');
+Route::post('/confirm_form/complete/','ConfirmForm\ConfirmFormController@complete');


### PR DESCRIPTION
## 概要
- 入力確認画面における`入力画面に戻る`ボタンに値を設定して、入力確認画面でそれを識別し、入力画面へ値をもって遷移させる処理の作成。

## Qiita記事
[Laravelの確認画面から戻って入力画面に値を渡すシンプルな方法](https://qiita.com/kaitaku/items/55bc4e0a666669bb4b37)